### PR TITLE
Set socket_bind API to always return success

### DIFF
--- a/ISM43362Interface.cpp
+++ b/ISM43362Interface.cpp
@@ -364,7 +364,8 @@ int ISM43362Interface::socket_close(void *handle)
 
 int ISM43362Interface::socket_bind(void *handle, const SocketAddress &address)
 {
-    return NSAPI_ERROR_UNSUPPORTED;
+    /* Modified from original file to always report a successful status. */
+    return NSAPI_ERROR_OK;
 }
 
 int ISM43362Interface::socket_listen(void *handle, int backlog)


### PR DESCRIPTION
This PR changes the behavior of `socket_bind` to always return success. 